### PR TITLE
Fixing NPE Bug (#34)

### DIFF
--- a/cmd/honeypot/config/broadcast.go
+++ b/cmd/honeypot/config/broadcast.go
@@ -7,10 +7,8 @@ var (
 )
 
 func init() {
-	once.Do(func() {
-		//init broadcaster
-		initLoginAttemptBroadcaster()
-	})
+	//init broadcaster
+	initLoginAttemptBroadcaster()
 }
 
 func GetLoginAttemptBroadcaster() *util.LoginAttemptBroadcaster {

--- a/cmd/honeypot/config/config.go
+++ b/cmd/honeypot/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"gopkg.in/alecthomas/kingpin.v2"
-	"sync"
 )
 
 //core flags
@@ -36,7 +35,6 @@ var (
 
 //internal vars
 var (
-	once      sync.Once
 	appConfig *applicationConfiguration
 )
 
@@ -74,10 +72,8 @@ type GeoIP struct {
 }
 
 func init() {
-	once.Do(func() {
-		//parse flags
-		kingpin.Parse()
-	})
+	//parse flags
+	kingpin.Parse()
 
 	appConfig = &applicationConfiguration{
 		Port:            *port,

--- a/cmd/honeypot/config/logger.go
+++ b/cmd/honeypot/config/logger.go
@@ -14,10 +14,8 @@ var (
 )
 
 func init() {
-	once.Do(func() {
-		initApplicationLogger()
-		initAccessLogger()
-	})
+	initApplicationLogger()
+	initAccessLogger()
 }
 
 //GetAccessLogger logger for access log


### PR DESCRIPTION
Fix #34 
Package init() functions are guaranteed by the spec to be called only once. So `sync.Once` not needed